### PR TITLE
Add option to change number of commits shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ docker run -d \
   -e SUPERVISOR_TOKEN=your_long_lived_access_token_here \
   -e HA_URL=http://homeassistant.local:8123 \
   --name home-assistant-version-control \
-  ghcr.io/saihgupr/homeassistantversioncontrol:latest
+  ghcr.io/saihgupr/home-assistant-version-control:latest
 ```
 
 Replace `/path/to/your/config` with the actual path to your Home Assistant configuration directory.
@@ -158,6 +158,7 @@ The application can be configured through the web UI Settings page or via enviro
 | **Retention Type** | Keep history based on time or number of versions | `time` |
 | **Retention Value** | How much history to keep (number of days/hours/weeks/months or versions) | `90` |
 | **Retention Unit** | Time unit for retention (hours, days, weeks, months) | `days` |
+| **Max Commits** | How many commits to show in the timeline | `days` |
 
 #### Environment Variable Configuration
 
@@ -181,6 +182,7 @@ For containerized deployments (especially when not persisting the `/data` direct
 | `RETENTION_TYPE` | Retention Type | String | `time`, `versions` | `time` |
 | `RETENTION_VALUE` | Retention Value | Number | ≥ 1 | `90` |
 | `RETENTION_UNIT` | Retention Unit | String | `hours`, `days`, `weeks`, `months` | `days` |
+| `MAX_COMMITS` | Max Commits | Number | ≥ 50 / ≤ 10000 | `50` |
 
 **Notes:**
 - Boolean values are case-insensitive and accept: `true`/`false`, `yes`/`no`, `1`/`0`
@@ -195,7 +197,7 @@ For containerized deployments (especially when not persisting the `/data` direct
 version: '3.8'
 services:
   havc:
-    image: ghcr.io/saihgupr/homeassistantversioncontrol:latest
+    image: ghcr.io/saihgupr/home-assistant-version-control:latest
     ports:
       - "54001:54001"
     volumes:
@@ -208,6 +210,7 @@ services:
       - RETENTION_TYPE=time
       - RETENTION_VALUE=30
       - RETENTION_UNIT=days
+      - MAX_COMMITS=50
 ```
 
 **Docker Run with environment variables:**
@@ -223,7 +226,7 @@ docker run -d \
   -e RETENTION_VALUE=30 \
   -e RETENTION_UNIT=days \
   --name home-assistant-version-control \
-  ghcr.io/saihgupr/homeassistantversioncontrol:latest
+  ghcr.io/saihgupr/home-assistant-version-control:latest
 ```
 
 **Validation and Logging:**
@@ -237,6 +240,7 @@ When the container starts, you'll see detailed logging showing where each settin
 [init]   retentionType: 'time' (default)
 [init]   retentionValue: 30 (env: RETENTION_VALUE)
 [init]   retentionUnit: 'days' (default)
+[init]   maxCommits: 50 (default)
 ```
 
 Invalid values will trigger warnings:

--- a/homeassistant-version-control/public/app.js
+++ b/homeassistant-version-control/public/app.js
@@ -230,6 +230,10 @@ async function loadSettings() {
         document.getElementById('retentionUnit').value = settings.retentionUnit;
         localStorage.setItem('retentionUnit', settings.retentionUnit);
 
+        // Max commits
+        document.getElementById('maxCommits').value = settings.maxCommits;
+        localStorage.setItem('maxCommits', settings.maxCommits);
+
         // Run cleanup on commit
 
       }
@@ -1218,6 +1222,7 @@ async function saveSettings() {
   const retentionValue = document.getElementById('retentionValue').value;
   const retentionUnit = document.getElementById('retentionUnit').value;
   const historyRetention = document.getElementById('historyRetention').checked;
+  const maxCommits = document.getElementById('maxCommits').value;
   const diffViewSplit = document.getElementById('diffViewSplit').checked;
   const newDiffViewFormat = diffViewSplit ? 'split' : 'unified';
   const newDiffStyle = document.getElementById('diffStyle').value;
@@ -1231,6 +1236,7 @@ async function saveSettings() {
   localStorage.setItem('retentionValue', retentionValue);
   localStorage.setItem('retentionUnit', retentionUnit);
   localStorage.setItem('historyRetention', historyRetention);
+  localStorage.setItem('maxCommits', maxCommits);
   localStorage.setItem('diffViewFormat', newDiffViewFormat);
   localStorage.setItem('diffStyle', newDiffStyle);
 
@@ -1252,6 +1258,7 @@ async function saveSettings() {
         retentionType,
         retentionValue,
         retentionUnit,
+        maxCommits,
         extensions: currentExtensions
       })
     });
@@ -1326,6 +1333,7 @@ async function loadCloudSyncSettings() {
     const data = await response.json();
 
     if (data.success) {
+      console.log(data);
       const settings = data.settings;
 
       // Update UI elements

--- a/homeassistant-version-control/public/index.html
+++ b/homeassistant-version-control/public/index.html
@@ -214,6 +214,48 @@
               </p>
             </div>
 
+            <div id="maxCommitsOptions" style="margin-bottom: 20px;">
+              <label style="display: block; margin-bottom: 8px;">
+                <span style="color: var(--text-primary); font-size: 14px;" data-i18n="settings.max_commits">Max Commits to Show</span>
+              </label>
+              <div class="custom-number-input-wrapper" style="position: relative;">
+                <input type="number" id="maxCommits" min="50" max="10000" value="50" style="
+                  width: 100%;
+                  padding: 10px 32px 10px 12px;
+                  background: var(--bg-tertiary);
+                  border: 1px solid var(--border-subtle);
+                  border-radius: var(--radius-md);
+                  color: var(--text-primary);
+                  font-size: 14px;
+                  -moz-appearance: textfield;
+                  appearance: textfield;
+                ">
+                <div class="custom-spinners"
+                  style="position: absolute; right: 2px; top: 2px; bottom: 2px; display: flex; flex-direction: column; width: 24px;">
+                  <button class="spinner-btn spinner-up" onclick="stepInput('maxCommits', 10)"
+                    style="flex: 1; border: none; background: transparent; cursor: pointer; display: flex; align-items: center; justify-content: center; padding: 0;">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none"
+                      stroke="#9ca3af" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"
+                      style="transform: rotate(180deg);">
+                      <polyline points="6 9 12 15 18 9"></polyline>
+                    </svg>
+                  </button>
+                  <button class="spinner-btn spinner-down" onclick="stepInput('maxCommits', -10)"
+                    style="flex: 1; border: none; background: transparent; cursor: pointer; display: flex; align-items: center; justify-content: center; padding: 0;">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none"
+                      stroke="#9ca3af" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+                      <polyline points="6 9 12 15 18 9"></polyline>
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <p style="color: var(--text-secondary); font-size: 12px; margin-top: 6px; margin-left: 2px;"
+                data-i18n="settings.max_commits_desc">
+                Maximum number of commits to display in the timeline (50-10000)
+              </p>
+            </div>
+            
+
             <div class="setting-item" style="margin-bottom: 20px;">
               <label style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;">
                 <span style="color: var(--text-primary); font-size: 14px;"

--- a/homeassistant-version-control/public/lang/en.json
+++ b/homeassistant-version-control/public/lang/en.json
@@ -154,6 +154,8 @@
     "debounce_time_desc": "Time to wait before creating a version after file changes",
     "history_retention": "Clean Up History",
     "history_retention_desc": "Merge versions older than a certain time period",
+    "max_commits": "Max Commits to Show",
+    "max_commits_desc": "Maximum number of commits to display in the timeline",
     "retention_type": "Retention Type",
     "retention_value": "Retention Value",
     "retention_unit": "Retention Unit",

--- a/homeassistant-version-control/server.js
+++ b/homeassistant-version-control/server.js
@@ -332,6 +332,7 @@ let runtimeSettings = {
   retentionType: 'age', // 'count' or 'age'
   retentionValue: 30,
   retentionUnit: 'days', // for age type
+  maxCommits: 50, 
   // Cloud Sync Settings
   cloudSync: {
     enabled: false,
@@ -383,6 +384,12 @@ const RUNTIME_SETTINGS_SCHEMA = {
     type: 'enum',
     values: ['hours', 'days', 'weeks', 'months'],
     envKey: 'RETENTION_UNIT'
+  },
+  maxCommits: {
+    type: 'number',
+    min: 50,
+    max: 10000,
+    envKey: 'MAX_COMMITS'
   }
 };
 
@@ -579,6 +586,7 @@ async function loadRuntimeSettings() {
   const envResult = loadSettingsFromEnv();
   runtimeSettings = { ...runtimeSettings, ...envResult.settings };
   Object.assign(settingSources, envResult.sources);
+  console.log(runtimeSettings);
 
   // Layer 2: Apply file settings (highest precedence)
   try {
@@ -1049,6 +1057,13 @@ app.post('/api/runtime-settings', async (req, res) => {
       runtimeSettings.retentionUnit = newSettings.retentionUnit;
     }
 
+    if (newSettings.maxCommits !== undefined) {
+      const maxCommits = parseInt(newSettings.maxCommits);
+      if (maxCommits >= 0) {
+        runtimeSettings.maxCommits = maxCommits;
+      }
+    }
+
     // Handle extensions settings
     if (newSettings.extensions !== undefined) {
       if (newSettings.extensions.include !== undefined && Array.isArray(newSettings.extensions.include)) {
@@ -1431,7 +1446,7 @@ app.get('/api/scripts/deleted', async (req, res) => {
 // Git History
 app.get('/api/git/history', async (req, res) => {
   try {
-    const log = await gitLog({ maxCount: 50 });
+    const log = await gitLog({ maxCount: runtimeSettings.maxCommits });
     res.json({ success: true, log });
   } catch (error) {
     res.status(500).json({ success: false, error: error.message });
@@ -1499,8 +1514,7 @@ app.get('/api/file-content', async (req, res) => {
 app.get('/api/git/file-history', async (req, res) => {
   try {
     const { filePath } = req.query;
-    const maxCount = 50; // Increased from 20 to show more history
-    const log = await gitLog({ file: filePath, maxCount });
+    const log = await gitLog({ file: filePath, maxCount: runtimeSettings.maxCommits });
 
     // Get current file hash
     let currentHash = '';


### PR DESCRIPTION
Looked through the code and saw that the number of commits/changes being shown was hard-coded to 50. As I had a default debounce time of 5 seconds, I easily hit the 50 commit visibility cap pretty quickly when testing out some changes. Figured it would be good to increase this, but make it an option so the default is still 50