### PR TITLE
fix: addon failed to build on HA Supervisor 2026.04.0+

### DIFF
--- a/homeassistant-version-control/Dockerfile
+++ b/homeassistant-version-control/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:latest
+ARG BUILD_FROM=ghcr.io/home-assistant/base:latest
 FROM $BUILD_FROM
 
 ENV LANG C.UTF-8


### PR DESCRIPTION
I applied arch agnostic base image as per HA docs to fix failures on arm64 after previous fix.  
Consider aligning build process to fully support new HA versions.  
https://developers.home-assistant.io/blog/2026/04/02/builder-migration/
Closes #32 