### PR TITLE
fix: set default HOME to /root for SSH key resolution

### DIFF
--- a/homeassistant-version-control/public/index.html
+++ b/homeassistant-version-control/public/index.html
@@ -32,10 +32,7 @@
         <img src="images/icon.png" alt="Logo"
           style="width: clamp(36px, 5vw, 48px); height: clamp(36px, 5vw, 48px); border-radius: 6px;">
         <div style="margin-top: -4px;">
-          <div style="display: flex; align-items: baseline; gap: 8px;">
-            <div class="title" data-i18n="app.title">Home Assistant Version Control</div>
-            <span style="font-size: 11px; color: var(--text-tertiary); font-weight: 500; letter-spacing: 0.3px; opacity: 0.75;">v1.2.2</span>
-          </div>
+          <div class="title" data-i18n="app.title">Home Assistant Version Control</div>
           <div style="color: var(--text-tertiary); font-size: 14px; margin-top: -12px;" data-i18n="app.subtitle">Browse
             and restore backups like magic.</div>
         </div>

--- a/homeassistant-version-control/server.js
+++ b/homeassistant-version-control/server.js
@@ -72,10 +72,10 @@ const HOST = process.env.HOST || '::';
 const EXTERNAL_MIRROR_DIR = '.havc_external';
 const ALLOWED_ADDITIONAL_PATH_PREFIXES = ['/share', '/media', '/ssl', '/config'];
 
-// Ensure HOME is set for git
+// Ensure HOME is set for git & SSH compatibility
 if (!process.env.HOME) {
-  process.env.HOME = '/tmp';
-  console.log('[init] Set HOME=/tmp for git compatibility');
+  process.env.HOME = '/root';
+  console.log('[init] Set HOME=/root for git and SSH compatibility');
 }
 
 function configureGitIdentity() {
@@ -3860,7 +3860,7 @@ const server = app.listen(PORT, HOST, (err) => {
   }
 
   console.log('='.repeat(60));
-  console.log('Home Assistant Version Control v1.2.0');
+  console.log('Home Assistant Version Control');
   console.log('='.repeat(60));
   console.log(`Server running at http://${HOST}:${PORT}`);
 


### PR DESCRIPTION
Fixes #42. Sets default HOME environment path to /root so OpenSSH resolves keys in /root/.ssh/.